### PR TITLE
映画削除時の挙動を修正

### DIFF
--- a/lib/models/movie_log_provider.dart
+++ b/lib/models/movie_log_provider.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 import 'movie.dart';
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
 
 class MovieLogProvider with ChangeNotifier {
   List<Movie> _movies = [];
@@ -113,16 +115,25 @@ class MovieLogProvider with ChangeNotifier {
     }
   }
 
-  // 映画情報を削除
-  Future<void> deleteMovie(String id) async {
+  Future<void> deleteMovie(Movie movie) async {
+    // Movieインスタンスに紐づいたディレクトリを削除
+    final directory = await getApplicationDocumentsDirectory();
+    final String movieDirPath = '${directory.path}/${movie.id}';
+    final Directory movieDir = Directory(movieDirPath);
+    if (movieDir.existsSync()) {
+      movieDir.deleteSync(recursive: true);
+    }
+
     // データベースから映画情報を削除
     await _moviesDatabase.delete(
       'movies',
       where: 'id = ?',
-      whereArgs: [id],
+      whereArgs: [movie.id],
     );
-    // メモリ上の映画情報リストからも削除
-    _movies.removeWhere((movie) => movie.id == id);
+
+    // メモリ上の映画情報リストから削除
+    _movies.removeWhere((m) => m.id == movie.id);
+
     notifyListeners();
   }
 

--- a/lib/screens/movie_detail.dart
+++ b/lib/screens/movie_detail.dart
@@ -50,18 +50,7 @@ class MovieDetailState extends State<MovieDetail> {
 
   // 削除ボタン押下時に呼ばれる関数
   void _deleteMovie() {
-    // 画像ファイルが存在する場合は削除
-    if (widget.movie.imagePath.isNotEmpty) {
-      final File imageFile = File(widget.movie.imagePath);
-      if (imageFile.existsSync()) {
-        imageFile.deleteSync();
-      }
-    }
-
-    // データベースから削除
-    _movieLogProvider.deleteMovie(widget.movie.id);
-
-    // 画面を閉じる
+    _movieLogProvider.deleteMovie(widget.movie);
     Navigator.pop(context);
   }
 


### PR DESCRIPTION
映画削除時の挙動をmovie_log_provider.dart内のdeleteMovie関数にまとめた。
映画詳細画面で削除ボタンを押下すると、
1. アプリ内ストレージに存在する、削除対象映画に紐づくディレクトリ
2. データベースの削除対象映画のメタ情報レコード
3. メモリ上の削除対象Movieインスタンス
が削除される。